### PR TITLE
Add new URL mixin for method-based views

### DIFF
--- a/incuna_test_utils/testcases/urls.py
+++ b/incuna_test_utils/testcases/urls.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.core.urlresolvers import resolve, reverse
 from django.test import TestCase
 
@@ -24,7 +26,7 @@ class URLsMixinBase(object):
         Assert that the view method/class that the URL resolves to is the
         correct one.
         """
-        pass
+        raise NotImplementedError
 
 
 class URLsMixinForViewMethod(URLsMixinBase):
@@ -45,7 +47,9 @@ class URLsMixinREST(URLsMixinBase):
 
 class URLsMixin(URLsMixinREST):
     """For backwards compatibility."""
-    pass
+    warnings.warn(
+        'URLsMixin is deprecated; use URLsMixinREST instead.',
+        DeprecationWarning)
 
 
 class URLsTestCase(URLsMixinREST, TestCase):


### PR DESCRIPTION
URLsTestCase supports class-based views, but not method-based views.  I made a method-based version while working on another project and figured it would be worth putting in here.
