### PR TITLE
IntegrationTestCase needs to make more sense

### DIFF
--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -18,24 +18,8 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
 
     A function-based view must be provided wrapped in `staticmethod`:
         view = staticmethod(view_func)
+    See superclass (BaseRequestTestCase) for more detail.
     """
-    def get_view_callable(self):
-        """
-        Returns the class's attached view, as a callable.
-
-        Checks self.view exists, and throws an ImproperlyConfigured exception
-        if it doesn't.  Otherwise, it returns the view, ensuring it's callable.
-        """
-        try:
-            view = self.view
-        except AttributeError:
-            message = "This test must have a 'view' attribute."
-            raise ImproperlyConfigured(message)
-        
-        try:
-            return view.as_view()
-        except AttributeError:
-            return view
 
     def access_view(self, *args, **kwargs):
         """
@@ -51,7 +35,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
         if request is None:
             request = self.create_request(add_session=True)
 
-        view_callable = self.get_view_callable()
+        view_callable = self.get_view()
         response = view_callable(request, *args, **kwargs)
 
         # Add the request to the response.

--- a/incuna_test_utils/testcases/request.py
+++ b/incuna_test_utils/testcases/request.py
@@ -21,8 +21,34 @@ class BaseRequestTestCase(TestCase):
 
     BaseRequestTestCase must be subclassed with a user_factory attribute to
     create a default user for the request.
+
+    A class- or function-based view can be attached to the test class as the
+    'view' attribute.  get_view() returns a callable version of that
+    view, abstracting over whether it's class- or function-based.  However,
+    due to a quirk of Python's way of attaching things to classes, any
+    function-based view must currently be added wrapped in `staticmethod()`:
+        view = view_class                   # class-based view
+        view = staticmethod(view_func)      # function-based view
     """
     request_factory = RequestFactory 
+
+    def get_view(self):
+        """
+        Returns the class's attached view, as a callable.
+
+        Checks self.view exists, and throws an ImproperlyConfigured exception
+        if it doesn't.  Otherwise, it returns the view, ensuring it's callable.
+        """
+        try:
+            view = self.view
+        except AttributeError:
+            message = "This test must have a 'view' attribute."
+            raise ImproperlyConfigured(message)
+        
+        try:
+            return view.as_view()
+        except AttributeError:
+            return view
 
     @staticmethod
     def add_session_to_request(request):


### PR DESCRIPTION
The new `IntegrationTestCase` is somewhat complicated, and provides some substantial abstractions.  It also doesn't handle function-based views well in the slightest.  I've reflowed it a bit to make more sense, made it deal with requests more smoothly, and added understanding of function-based views.  And lots and lots of comments.

@meshy @Ian-Foote review please? :)
