### PR TITLE
Add missing requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,7 @@
 -e .
 dj-database-url==0.3.0
+django==1.7
+django-mptt==0.6.1
 djangorestframework==2.4.2
 factory-boy==2.4.1
 feincms==1.10.0


### PR DESCRIPTION
Running `make test` with a project freshly checked result in missing dependencies.
