### PR TITLE
Add the ability to assert content is or isn't in data

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,13 @@ and `response.context_data`. If a `request` is not provided, `render_to_str` use
   * `access_view_and_render_response` wraps `access_view` and `render_to_str`.
 It also checks the `response.status_code` is as expected. The default
 `expected_status` is `200` (`HTTP_OK`).
+  * `assert_presence` checks that an item does or doesn't appear in a container.
   * `assert_count` checks that an item appears in a container an expected number
 of times.
+  * `assert_presence_multiple` and `assert_count_multiple` run one or more assertions in
+  a single method call.
+  * `render_view_and_assert_content` and `render_view_and_assert_content_counts` combine
+  a call to `access_view_and_render_response` with a multiple-assert call on the result.
 
 
 ### `api_request.BaseAPIRequestTestCase`

--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -133,7 +133,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
 
     @staticmethod
     def _assert_count_message(needle, haystack, count, actual_count):
-        # Build a verbose error message in case we need it.
+        """Build a verbose error message in case we need it."""
         plural = '' if count == 1 else 's'
         message = (
             'Expected {count} instance{plural} of {needle}, but found ' +
@@ -144,6 +144,17 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
             plural=plural,
             needle=needle,
             actual_count=actual_count,
+            haystack=haystack,
+        )
+
+    @staticmethod
+    def _assert_presence_message(needle, haystack, is_present):
+        """Build a verbose error message in case we need it."""
+        contradiction = '' if is_present else 'not '
+        message = 'Expected {contradiction}to find {needle} in {haystack}'
+        return message.format(
+            contradiction=contradiction,
+            needle=needle,
             haystack=haystack,
         )
 
@@ -160,3 +171,16 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
         message = self._assert_count_message(*message_args)
 
         self.assertEqual(count, actual_count, message)
+
+    def assert_presence(self, needle, haystack, is_present):
+        """
+        Assert that 'needle' occurs at least once in 'haystack' iff `is_present` is true.
+
+        Outputs a verbose error message when it fails.
+        """
+        contains = needle in haystack
+
+        message_args = (needle, haystack, is_present)
+        message = self._assert_presence_message(*message_args)
+
+        self.assertEqual(is_present, contains, message)

--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -205,7 +205,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
 
     def assert_presence(self, needle, haystack, is_present):
         """
-        Assert that 'needle' occurs at least once in 'haystack' iff `is_present` is True.
+        Assert that 'needle' occurs in 'haystack' if and only if `is_present` is True.
 
         Outputs a verbose error message when it fails.
         """

--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -165,7 +165,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
     @staticmethod
     def _assert_count_message(needle, haystack, count, actual_count):
         """Build a verbose error message in case we need it."""
-        plural = u'' if count == 1 else u's'
+        plural = '' if count == 1 else 's'
         message = (
             u'Expected {count} instance{plural} of {needle}, but found ' +
             u'{actual_count}, in {haystack}'

--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -181,7 +181,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
     @staticmethod
     def _assert_presence_message(needle, haystack, is_present):
         """Build a verbose error message in case we need it."""
-        contradiction = '' if is_present else 'not '
+        contradiction = '' if is_present else 'not '  # Note the trailing space in 'not '!
         message = 'Expected {contradiction}to find {needle} in {haystack}'
         return message.format(
             contradiction=contradiction,

--- a/incuna_test_utils/testcases/integration.py
+++ b/incuna_test_utils/testcases/integration.py
@@ -165,10 +165,10 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
     @staticmethod
     def _assert_count_message(needle, haystack, count, actual_count):
         """Build a verbose error message in case we need it."""
-        plural = '' if count == 1 else 's'
+        plural = u'' if count == 1 else u's'
         message = (
-            'Expected {count} instance{plural} of {needle}, but found ' +
-            '{actual_count}, in {haystack}'
+            u'Expected {count} instance{plural} of {needle}, but found ' +
+            u'{actual_count}, in {haystack}'
         )
         return message.format(
             count=count,
@@ -182,7 +182,7 @@ class BaseIntegrationTestCase(BaseRequestTestCase):
     def _assert_presence_message(needle, haystack, is_present):
         """Build a verbose error message in case we need it."""
         contradiction = '' if is_present else 'not '  # Note the trailing space in 'not '!
-        message = 'Expected {contradiction}to find {needle} in {haystack}'
+        message = u'Expected {contradiction}to find {needle} in {haystack}'
         return message.format(
             contradiction=contradiction,
             needle=needle,

--- a/tests/testcases/test_integration.py
+++ b/tests/testcases/test_integration.py
@@ -70,6 +70,20 @@ class TestIntegration:
         with pytest.raises(AssertionError):
             simple_integration.assert_count(needle, haystack, count)
 
+    def test_assert_presence(self, simple_integration):
+        haystack = [1, 1, 3, 1, 2, 4]
+        needle = 1
+        is_present = True
+        simple_integration.assert_presence(needle, haystack, is_present)
+
+    def test_assert_presence_fail(self, simple_integration):
+        haystack = [1, 1, 3, 1, 2, 4]
+        needle = 1
+        is_present = False
+
+        with pytest.raises(AssertionError):
+            simple_integration.assert_presence(needle, haystack, is_present)
+
     def test__assert_count_message(self, simple_integration):
         haystack = [1, 1, 3, 1, 2, 4]
         needle = 1
@@ -96,6 +110,32 @@ class TestIntegration:
 
         message_args = (needle, haystack, count, actual_count)
         message = simple_integration._assert_count_message(*message_args)
+        assert message == expected_message
+
+    def test__assert_presence_message(self, simple_integration):
+        haystack = [1, 1, 3, 1, 2, 4]
+        needle = 1
+        presence = False
+
+        expected_message_args = (needle, haystack)
+        expected_message = 'Expected not to find {} in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, presence)
+        message = simple_integration._assert_presence_message(*message_args)
+        assert message == expected_message
+
+    def test__assert_presence_message_present(self, simple_integration):
+        haystack = [1, 1, 3, 1, 2, 4]
+        needle = 18
+        presence = True
+
+        expected_message_args = (needle, haystack)
+        expected_message = 'Expected to find {} in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, presence)
+        message = simple_integration._assert_presence_message(*message_args)
         assert message == expected_message
 
     def test_render_to_str(self, template_view_integration):

--- a/tests/testcases/test_integration.py
+++ b/tests/testcases/test_integration.py
@@ -56,88 +56,6 @@ class TestIntegration:
         with pytest.raises(AttributeError):
             response.request.session
 
-    def test_assert_count(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        count = 3
-        simple_integration.assert_count(needle, haystack, count)
-
-    def test_assert_count_fail(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        count = 4
-
-        with pytest.raises(AssertionError):
-            simple_integration.assert_count(needle, haystack, count)
-
-    def test_assert_presence(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        is_present = True
-        simple_integration.assert_presence(needle, haystack, is_present)
-
-    def test_assert_presence_fail(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        is_present = False
-
-        with pytest.raises(AssertionError):
-            simple_integration.assert_presence(needle, haystack, is_present)
-
-    def test__assert_count_message(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        count = 1
-        actual_count = haystack.count(needle)
-
-        expected_message_args = (count, needle, actual_count, haystack)
-        expected_message = 'Expected {} instance of {}, but found {}, in {}'
-        expected_message = expected_message.format(*expected_message_args)
-
-        message_args = (needle, haystack, count, actual_count)
-        message = simple_integration._assert_count_message(*message_args)
-        assert message == expected_message
-
-    def test__assert_count_message_plural(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        count = 4
-        actual_count = haystack.count(needle)
-
-        expected_message_args = (count, needle, actual_count, haystack)
-        expected_message = 'Expected {} instances of {}, but found {}, in {}'
-        expected_message = expected_message.format(*expected_message_args)
-
-        message_args = (needle, haystack, count, actual_count)
-        message = simple_integration._assert_count_message(*message_args)
-        assert message == expected_message
-
-    def test__assert_presence_message(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 1
-        presence = False
-
-        expected_message_args = (needle, haystack)
-        expected_message = 'Expected not to find {} in {}'
-        expected_message = expected_message.format(*expected_message_args)
-
-        message_args = (needle, haystack, presence)
-        message = simple_integration._assert_presence_message(*message_args)
-        assert message == expected_message
-
-    def test__assert_presence_message_present(self, simple_integration):
-        haystack = [1, 1, 3, 1, 2, 4]
-        needle = 18
-        presence = True
-
-        expected_message_args = (needle, haystack)
-        expected_message = 'Expected to find {} in {}'
-        expected_message = expected_message.format(*expected_message_args)
-
-        message_args = (needle, haystack, presence)
-        message = simple_integration._assert_presence_message(*message_args)
-        assert message == expected_message
-
     def test_render_to_str(self, template_view_integration):
         request = template_view_integration.create_request(auth=False)
         response = template_view_integration.access_view(request=request)
@@ -152,3 +70,157 @@ class TestIntegration:
             request=request,
         )
         assert content == TEMPLATE_CONTENT
+
+    def test_assert_count(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        count = 4
+        simple_integration.assert_count(needle, haystack, count)
+
+    def test_assert_count_fail(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        count = 19
+
+        with pytest.raises(AssertionError):
+            simple_integration.assert_count(needle, haystack, count)
+
+    def test_assert_presence(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        is_present = True
+        simple_integration.assert_presence(needle, haystack, is_present)
+
+    def test_assert_presence_fail(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        is_present = False
+
+        with pytest.raises(AssertionError):
+            simple_integration.assert_presence(needle, haystack, is_present)
+
+    def test__assert_count_message(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        count = 1
+        actual_count = haystack.count(needle)
+
+        expected_message_args = (count, needle, actual_count, haystack)
+        expected_message = 'Expected {} instance of {}, but found {}, in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, count, actual_count)
+        message = simple_integration._assert_count_message(*message_args)
+        assert message == expected_message
+
+    def test__assert_count_message_plural(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        count = 7
+        actual_count = haystack.count(needle)
+
+        expected_message_args = (count, needle, actual_count, haystack)
+        expected_message = 'Expected {} instances of {}, but found {}, in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, count, actual_count)
+        message = simple_integration._assert_count_message(*message_args)
+        assert message == expected_message
+
+    def test__assert_presence_message(self, simple_integration):
+        haystack = 'aabacad'
+        needle = 'a'
+        presence = False
+
+        expected_message_args = (needle, haystack)
+        expected_message = 'Expected not to find {} in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, presence)
+        message = simple_integration._assert_presence_message(*message_args)
+        assert message == expected_message
+
+    def test__assert_presence_message_present(self, simple_integration):
+        haystack = 'aabacad'
+        needle = '18'
+        presence = True
+
+        expected_message_args = (needle, haystack)
+        expected_message = 'Expected to find {} in {}'
+        expected_message = expected_message.format(*expected_message_args)
+
+        message_args = (needle, haystack, presence)
+        message = simple_integration._assert_presence_message(*message_args)
+        assert message == expected_message
+
+    def test_assert_count_multiple(self, simple_integration):
+        haystack = 'aabacad'
+        assertions = {
+            'a': 4,
+            'b': 1,
+        }
+
+        simple_integration.assert_count_multiple(haystack, **assertions)
+
+    def test_assert_count_multiple_fail(self, simple_integration):
+        haystack = 'aabacad'
+        assertions = {
+            'a': 4,
+            'b': 7,
+        }
+
+        with pytest.raises(AssertionError):
+            simple_integration.assert_count_multiple(haystack, **assertions)
+
+    def test_assert_presence_multiple(self, simple_integration):
+        haystack = 'aabacad'
+        assertions = {
+            'a': True,
+            'z': False,
+        }
+
+        simple_integration.assert_presence_multiple(haystack, **assertions)
+
+    def test_assert_presence_multiple_fail(self, simple_integration):
+        haystack = 'aabacad'
+        assertions = {
+            'a': True,
+            'z': True,
+        }
+
+        with pytest.raises(AssertionError):
+            simple_integration.assert_presence_multiple(haystack, **assertions)
+
+    @pytest.mark.django_db
+    def test_render_view_and_assert_content(self, template_view_integration):
+        assertions = {
+            TEMPLATE_CONTENT: True,
+        }
+
+        template_view_integration.render_view_and_assert_content(assertions)
+
+    @pytest.mark.django_db
+    def test_render_view_and_assert_content_fail(self, template_view_integration):
+        assertions = {
+            'A string not in the template content': True,
+        }
+
+        with pytest.raises(AssertionError):
+            template_view_integration.render_view_and_assert_content(assertions)
+
+    @pytest.mark.django_db
+    def test_render_view_and_assert_content_counts(self, template_view_integration):
+        assertions = {
+            TEMPLATE_CONTENT: 1,
+        }
+
+        template_view_integration.render_view_and_assert_content_counts(assertions)
+
+    @pytest.mark.django_db
+    def test_render_view_and_assert_content_counts_fail(self, template_view_integration):
+        assertions = {
+            TEMPLATE_CONTENT: 6,
+        }
+
+        with pytest.raises(AssertionError):
+            template_view_integration.render_view_and_assert_content_counts(assertions)

--- a/tests/testcases/test_integration.py
+++ b/tests/testcases/test_integration.py
@@ -132,9 +132,8 @@ class TestIntegration:
         needle = 'a'
         presence = False
 
-        expected_message_args = (needle, haystack)
         expected_message = 'Expected not to find {} in {}'
-        expected_message = expected_message.format(*expected_message_args)
+        expected_message = expected_message.format(needle, haystack)
 
         message_args = (needle, haystack, presence)
         message = simple_integration._assert_presence_message(*message_args)
@@ -145,9 +144,8 @@ class TestIntegration:
         needle = '18'
         presence = True
 
-        expected_message_args = (needle, haystack)
         expected_message = 'Expected to find {} in {}'
-        expected_message = expected_message.format(*expected_message_args)
+        expected_message = expected_message.format(needle, haystack)
 
         message_args = (needle, haystack, presence)
         message = simple_integration._assert_presence_message(*message_args)


### PR DESCRIPTION
Specifying precise counts every time has proven itself to be a pain, and the tests have to be updated all the time to reflect minor changes in template layouts or data display.

Additionally, there are helper methods in other projects built on top of those already here that we can make good use of!

@incuna/backend review please?