### PR TITLE
Fix bugs in the image factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog for incuna-test-utils
 ============================
 
+Upcoming
+------
+* Bugfix: Ensure the methods and factory fields in `factories.images` all output Django
+  File objects.
+
 v6.2.0
 ------
 * Add `factories.images` module with usefuls for handling images in tests.

--- a/incuna_test_utils/factories/images.py
+++ b/incuna_test_utils/factories/images.py
@@ -1,9 +1,15 @@
+import os
 from io import BytesIO
 
 import factory
+from django.core.files import File
 from PIL import Image
 
 from ..utils import TEST_SERVER
+
+
+directory = os.path.dirname(__file__)
+IMAGE_PATH = os.path.join(directory, 'images/image.png')
 
 
 def simple_png():
@@ -32,7 +38,7 @@ class LocalFileField(factory.django.FileField):
     """
     def __init__(self, *args, **kwargs):
         defaults = {
-            'from_path': 'incuna_test_utils/factories/images/image.png',
+            'from_path': IMAGE_PATH,
         }
         defaults.update(kwargs)
         super(LocalFileField, self).__init__(*args, **defaults)
@@ -49,9 +55,9 @@ class SimplePngFileField(factory.LazyAttribute):
     """
     def __init__(self, method=None, *args, **kwargs):
         if not method:
-            def png(a):
-                return simple_png()
-            method = png
+            def png_file(a):
+                return File(simple_png())
+            method = png_file
         super(SimplePngFileField, self).__init__(method, *args, **kwargs)
 
 
@@ -74,4 +80,4 @@ def uploadable_file():
     passed in using `files`, which correlates to `request.FILES`. Other form data can be
     passed in using `data` as normal.
     """
-    return open('incuna_test_utils/factories/images/image.png', mode='rb')
+    return File(open(IMAGE_PATH, mode='rb'))

--- a/tests/factory_tests/test_images.py
+++ b/tests/factory_tests/test_images.py
@@ -15,9 +15,9 @@ except NameError:
 
 def test_local_file_field():
     class FileFactory(factory.StubFactory):
-        file = images.LocalFileField()
+        image = images.LocalFileField()
 
-    built_file = FileFactory.build().file
+    built_file = FileFactory.build().image
     assert isinstance(built_file, File)
     assert isinstance(built_file.file, FILE_TYPE)
 
@@ -26,10 +26,12 @@ def test_simple_png_file_field():
     class FileFactory(factory.StubFactory):
         image = images.SimplePngFileField()
 
-    image = FileFactory.build().image
-    assert isinstance(image, BytesIO)
+    built_file = FileFactory.build().image
+    assert isinstance(built_file, File)
+    assert isinstance(built_file.file, BytesIO)
 
 
 def test_uploadable_file():
     built_file = images.uploadable_file()
-    assert isinstance(built_file, FILE_TYPE)
+    assert isinstance(built_file, File)
+    assert isinstance(built_file.file, FILE_TYPE)


### PR DESCRIPTION
All sorts of errors!  The moment I tried to use the new `factories.images` features in a project, everything exploded.  Two main problems:
* The file paths to the little `image.png` need to be constructed using code.
* The file fields all need to output Django `File` objects, as does `uploadable_file()`.  This change does make them look consistent, which is nice.

@incuna/backend quick review please?