### PR TITLE
assert_url_matches_view passes when as_view is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog for incuna-test-utils
 ============================
 
+v6.3.1
+------
+
+* Ensure `assert_url_matches_view` fails if `.as_view()` has been forgotten.
+
 v6.3.0
 ------
 

--- a/incuna_test_utils/testcases/urls.py
+++ b/incuna_test_utils/testcases/urls.py
@@ -1,3 +1,5 @@
+import inspect
+
 from django.core.urlresolvers import resolve, reverse
 from django.test import TestCase
 
@@ -26,6 +28,12 @@ class URLTestMixin(object):
             self.assertEqual(resolved_view.cls, view)
         else:
             self.assertEqual(resolved_view.__name__, view.__name__)
+
+        message = 'Resolved view `{}` is a class. Did you forget `.as_view()`?'
+        self.assertFalse(
+            inspect.isclass(resolved_view),
+            message.format(resolved_view),
+        )
 
 
 class URLTestCase(URLTestMixin, TestCase):

--- a/tests/testcases/test_urls.py
+++ b/tests/testcases/test_urls.py
@@ -1,3 +1,5 @@
+import pytest
+
 from incuna_test_utils.testcases.urls import URLTestCase
 
 from .. import views
@@ -24,3 +26,11 @@ class TestURLTestCase(URLTestCase):
             expected_url='/bar/',
             url_name='api-view',
         )
+
+    def test_assert_url_matches_view_missing_as_view(self):
+        with pytest.raises(AssertionError):
+            self.assert_url_matches_view(
+                view=views.MyAPIView,
+                expected_url='/spam/',
+                url_name='missing-as-view',
+            )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -13,5 +13,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url('foo/', views.MyView.as_view(), name='class-view'),
     url('bar/', views.MyAPIView.as_view(), name='api-view'),
+    url('spam/', views.MyAPIView, name='missing-as-view'),
     url('', views.my_view, name='function-view'),
 ]


### PR DESCRIPTION
When using a class-based view, a urls.py with a missing `.as_view` method doesn't fail an `assert_url_matches_view` test.

Incorrect:
```python
url(regex, ViewClass, url_name)
```

Correct:
```python
url(regex, ViewClass.as_view(), url_name)
```

We should make sure `assert_url_matches_view` fails with the first example and passes with the second.