### PR TITLE
Added get_field_by_name, another deprecated function from `Model._meta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog for incuna-test-utils
 ============================
 
+upcoming
+--------
+
+* Add additional deprecated method `get_field_by_name`
+
 v6.5.0
 ------
 

--- a/incuna_test_utils/utils.py
+++ b/incuna_test_utils/utils.py
@@ -54,3 +54,18 @@ def get_all_field_names(model):
             if not (field.many_to_one and field.related_model is None)
         )))
     return fields
+
+
+def get_field_by_name(model, field_name):
+    """Returns a tuple of (field, model, direct, m2m)"""
+    try:
+        field_info = model._meta.get_field_by_name(field_name)
+    except AttributeError:
+        field = model._meta.get_field(field_name)
+        field_info = (
+            field,
+            field.model,
+            not field.auto_created or field.concrete,
+            field.many_to_many,
+        )
+    return field_info

--- a/tests/models.py
+++ b/tests/models.py
@@ -6,3 +6,11 @@ class User(models.Model):
     name = models.CharField(max_length=255)
 
     USERNAME_FIELD = 'email'
+
+
+class Relation(models.Model):
+    pass
+
+
+class ManyRelated(models.Model):
+    relation = models.ManyToManyField(Relation)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from incuna_test_utils import utils
 
-from .models import User
+from .models import User, ManyRelated
 
 
 class Parent(object):
@@ -52,3 +52,19 @@ def test_get_all_field_names():
     assert isinstance(fields, list)
     # Convert to set as list could complain about ordering in equality check
     assert set(fields) == {'id', 'email', 'name'}
+
+
+def test_get_field_by_name():
+    field = utils.get_field_by_name(User, 'email')
+    assert field[0] == User._meta.get_field('email')
+    assert not field[1]
+    assert field[2]
+    assert not field[3]
+
+
+def test_get_field_by_name_many_related():
+    field = utils.get_field_by_name(ManyRelated, 'relation')
+    assert field[0] == ManyRelated._meta.get_field('relation')
+    assert not field[1]
+    assert field[2]
+    assert field[3]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from incuna_test_utils import utils
 
-from .models import User, ManyRelated
+from .models import ManyRelated, User
 
 
 class Parent(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,16 +55,16 @@ def test_get_all_field_names():
 
 
 def test_get_field_by_name():
-    field = utils.get_field_by_name(User, 'email')
-    assert field[0] == User._meta.get_field('email')
-    assert not field[1]
-    assert field[2]
-    assert not field[3]
+    field, model, direct, m2m = utils.get_field_by_name(User, 'email')
+    assert field == User._meta.get_field('email')
+    assert not model
+    assert direct
+    assert not m2m
 
 
 def test_get_field_by_name_many_related():
-    field = utils.get_field_by_name(ManyRelated, 'relation')
-    assert field[0] == ManyRelated._meta.get_field('relation')
-    assert not field[1]
-    assert field[2]
-    assert field[3]
+    field, model, direct, m2m = utils.get_field_by_name(ManyRelated, 'relation')
+    assert field == ManyRelated._meta.get_field('relation')
+    assert not model
+    assert direct
+    assert m2m


### PR DESCRIPTION
Based on: https://docs.djangoproject.com/en/1.10/ref/models/meta/#migrating-from-the-old-api

@incuna/backend 