### PR TITLE
Show warnings raised when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ release:
 	python setup.py register sdist bdist_wheel upload
 
 test:
-	@py.test incuna_test_utils tests
+	@py.test -Wmodule incuna_test_utils tests
 	@flake8 .
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 -e .
 django>=1.8,<1.9
-djangorestframework>=3.0.5,<4
+djangorestframework>=3.0.5,<3.7
 dj-database-url==0.4.1
-factory-boy==2.7.0
+factory-boy==2.8.1
 feincms==1.12.1
 flake8==2.5.4
 flake8-import-order==0.7
 mock==2.0.0
-psycopg2==2.6.1
-py==1.4.31
-pytest==2.9.1
-pytest-cov==2.2.1
-pytest-django==2.9.1
+psycopg2==2.7.3.2
+py==1.4.34
+pytest==3.1.3
+pytest-cov==2.5.1
+pytest-django==3.1.2
 pytest-pythonpath==0.7


### PR DESCRIPTION
This requires an update of pytest and some related libraries, and should aid the transition to Django 2.0 when the time comes.

- ~~Rebase once #67 is merged.~~ #68 has been rolled into this.